### PR TITLE
Added unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.23.0)
 project(easyqueue
-        DESCRIPTION "A simple queue implementation intended to support flexible applicability with an easy-to-use interface."
-        HOMEPAGE_URL "https://github.com/null-default/easyqueue"
-        LANGUAGES C)
+    DESCRIPTION "A simple queue implementation intended to support flexible applicability with an easy-to-use interface."
+    HOMEPAGE_URL "https://github.com/null-default/easyqueue"
+    LANGUAGES C)
 
 # Semantic Versioning, for the API version.
 set(EASYQUEUE_MAJOR_VERSION 1)  # increment for incompatible API changes
@@ -13,13 +13,14 @@ set(EASYQUEUE_APIVERSION ${EASYQUEUE_MAJOR_VERSION}.${EASYQUEUE_MINOR_VERSION})
 # Shared Object Versioning compatible with libtool's -version-info, for the ABI version.
 #   Ref: https://autotools.io/libtool/version.html
 set(EASYQUEUE_CURRENT_VERSION 1)   # increment whenever an interface has been added, removed, or changed
-set(EASYQUEUE_REVISION_VERSION 0)  # always increment regardless of changes
+set(EASYQUEUE_REVISION_VERSION 1)  # always increment regardless of changes
 set(EASYQUEUE_AGE_VERSION 0)       # only increment if ABI changes are backwards-compatible
 math(EXPR EASYQUEUE_SOVERSION "${EASYQUEUE_CURRENT_VERSION} - ${EASYQUEUE_AGE_VERSION}")
 set(EASYQUEUE_VERSION ${EASYQUEUE_SOVERSION}.${EASYQUEUE_AGE_VERSION}.${EASYQUEUE_REVISION_VERSION})
 
 # Define any boolean options that will tune the build.
 option(EASYQUEUE_BUILD_32 "Build 32-bit binaries instead of 64-bit." OFF)
+option(EASYQUEUE_BUILD_UNIT_TESTS "Build unit tests included in the repository. Unit tests use the Unity framework, which must be installed on the system." OFF)
 
 # Allow the fixed-size buffer's capacity to be configured.
 set(EASYQUEUE_DEFAULT_FIXED_BUFFER_CAPACITY 32)
@@ -30,53 +31,61 @@ endif()
 # Build a shared object.
 add_library(${PROJECT_NAME} SHARED)
 target_compile_definitions(${PROJECT_NAME}
-        PUBLIC EZQ_FIXED_BUFFER_CAPACITY=${EASYQUEUE_FIXED_BUFFER_CAPACITY})
+    PUBLIC EZQ_FIXED_BUFFER_CAPACITY=${EASYQUEUE_FIXED_BUFFER_CAPACITY})
 set_target_properties(${PROJECT_NAME}
-        PROPERTIES C_STANDARD 90
-                   C_STANDARD_REQUIRED ON
-                   C_EXTENSIONS OFF
-                   POSITION_INDEPENDENT_CODE ON)
+    PROPERTIES
+        C_STANDARD 90
+        C_STANDARD_REQUIRED ON
+        C_EXTENSIONS OFF
+        POSITION_INDEPENDENT_CODE ON)
 target_compile_options(${PROJECT_NAME}
-        PRIVATE -Wall -Werror -Wextra -Wpedantic)
+    PRIVATE -Wall -Werror -Wextra -Wpedantic)
 target_sources(${PROJECT_NAME}
-        PRIVATE src/easyqueue.c
-        PUBLIC FILE_SET easyqueue_headers
-                        TYPE HEADERS
-                        BASE_DIRS include
-                        FILES include/easyqueue.h)
+    PRIVATE src/easyqueue.c
+    PUBLIC
+        FILE_SET easyqueue_headers
+            TYPE HEADERS
+            BASE_DIRS include
+            FILES include/easyqueue.h)
 target_link_options(${PROJECT_NAME} PRIVATE -nostdlib)
 
 # Build a static archive.
 add_library(${PROJECT_NAME}_static STATIC)
 target_compile_definitions(${PROJECT_NAME}_static
-        PUBLIC EZQ_FIXED_BUFFER_CAPACITY=${EASYQUEUE_FIXED_BUFFER_CAPACITY})
+    PUBLIC EZQ_FIXED_BUFFER_CAPACITY=${EASYQUEUE_FIXED_BUFFER_CAPACITY})
 set_target_properties(${PROJECT_NAME}_static
-        PROPERTIES C_STANDARD 90
-                   C_STANDARD_REQUIRED ON
-                   C_EXTENSIONS OFF
-                   POSITION_INDEPENDENT_CODE ON)
+    PROPERTIES
+        C_STANDARD 90
+        C_STANDARD_REQUIRED ON
+        C_EXTENSIONS OFF
+        POSITION_INDEPENDENT_CODE ON)
 target_compile_options(${PROJECT_NAME}_static
-        PRIVATE -Wall -Werror -Wextra -Wpedantic)
+    PRIVATE -Wall -Werror -Wextra -Wpedantic)
 target_sources(${PROJECT_NAME}_static
-        PRIVATE src/easyqueue.c
-        PUBLIC FILE_SET easyqueue_headers
-                        TYPE HEADERS
-                        BASE_DIRS include
-                        FILES include/easyqueue.h)
+    PRIVATE src/easyqueue.c
+    PUBLIC
+        FILE_SET easyqueue_headers
+            TYPE HEADERS
+            BASE_DIRS include
+            FILES include/easyqueue.h)
 
 # Set additional flags for 32-bit builds.
 if(EASYQUEUE_BUILD_32)
     set_target_properties(${PROJECT_NAME}
-            PROPERTIES COMPILE_FLAGS "-m32"
-                       LINK_FLAGS "-m32")
+        PROPERTIES
+            COMPILE_FLAGS "-m32"
+            LINK_FLAGS "-m32")
     target_compile_options(${PROJECT_NAME}
-            PRIVATE -fno-stack-protector) # is this the best option..?
+        PRIVATE
+            -fno-stack-protector) # is this the best option..?
 
     set_target_properties(${PROJECT_NAME}_static
-            PROPERTIES COMPILE_FLAGS "-m32"
-                       LINK_FLAGS "-m32")
+        PROPERTIES
+            COMPILE_FLAGS "-m32"
+            LINK_FLAGS "-m32")
     target_compile_options(${PROJECT_NAME}_static
-            PRIVATE -fno-stack-protector)
+        PRIVATE
+            -fno-stack-protector)
 endif()
 
 # Example executables that demonstrate usage of the library can be compiled if
@@ -85,9 +94,24 @@ if(EASYQUEUE_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
+# If unit test building is specified, include CTest.
+#   NOTE: 32-bit builds of unit tests are not currently supported.
+if(EASYQUEUE_BUILD_UNIT_TESTS)
+    find_library(UNITY_TESTS
+        NAMES unity)
+    include(CTest)
+    add_executable(easyqueue_unit_tests src/easyqueue.tests.c)
+    target_link_libraries(easyqueue_unit_tests
+        PRIVATE
+            ${PROJECT_NAME}_static
+            ${UNITY_TESTS})
+    add_test(NAME easyqueue_unit_tests
+        COMMAND easyqueue_unit_tests)
+endif()
+
 # Set installation rules
 install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_static
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        FILE_SET easyqueue_headers)
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    FILE_SET easyqueue_headers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(easyqueue
 
 # Semantic Versioning, for the API version.
 set(EASYQUEUE_MAJOR_VERSION 1)  # increment for incompatible API changes
-set(EASYQUEUE_MINOR_VERSION 0)  # increment with new backwards-compatible functionality
+set(EASYQUEUE_MINOR_VERSION 1)  # increment with new backwards-compatible functionality
 set(EASYQUEUE_PATCH_VERSION 0)  # increment with backwards-compatible bugfixes
 set(EASYQUEUE_APIVERSION ${EASYQUEUE_MAJOR_VERSION}.${EASYQUEUE_MINOR_VERSION})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,0 @@
-# The library uses as old a C standard as possible to maximize portability.
-set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 90
-                                                 C_STANDARD_REQUIRED On
-                                                 C_EXTENSIONS Off)
-target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Werror -Wextra -Wpedantic)
-target_sources(${PROJECT_NAME} PRIVATE easyqueue.c)

--- a/src/easyqueue.c
+++ b/src/easyqueue.c
@@ -441,9 +441,14 @@ ezq_list_pop(
     p_front = p_ll->p_head;
     p_ll->p_head = p_ll->p_head->p_next;
     --p_ll->count;
+    if (0 == p_ll->count)
+    {
+        p_ll->p_tail = NULL;
+    }
 
     *pp_item = p_front->p_item;
     p_front->p_item = NULL;
+    p_front->p_next = NULL;
 
     if (NULL != free_fn)
     {

--- a/src/easyqueue.c
+++ b/src/easyqueue.c
@@ -313,6 +313,11 @@ ezq_destroy(
         estat = EZQ_STATUS_NULL_QUEUE;
         goto done;
     }
+    if (p_queue->dynamic.count > 0 && NULL == p_queue->free_fn)
+    {
+        estat = EZQ_STATUS_NO_FREE_FN;
+        goto done;
+    }
 
     ezq_destroy_unsafe(p_queue, item_cleanup_fn, p_args);
 
@@ -487,4 +492,9 @@ ezq_destroy_unsafe(
             item_cleanup_fn(p_item, p_args);
         }
     }
+
+    /* Clear the other fields of the queue. */
+    p_queue->alloc_fn = NULL;
+    p_queue->free_fn = NULL;
+    p_queue->capacity = 0;
 } /* ezq_destroy_unsafe */

--- a/src/easyqueue.tests.c
+++ b/src/easyqueue.tests.c
@@ -92,11 +92,141 @@ test__ezq_init__null_queue__failure(void)
     TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_NULL_QUEUE, estat);
 } /* test__ezq_init__null_queue__failure */
 
+static void
+test__ezq_push__standard__success(void)
+{
+
+} /* test__ezq_push__standard__success */
+
+static void
+test__ezq_push__null_queue__failure(void)
+{
+
+} /* test__ezq_push__null_queue__failure */
+
+static void
+test__ezq_push__null_item__failure(void)
+{
+
+} /* test__ezq_push__null_item__failure */
+
+static void
+test__ezq_push__capacity_full__failure(void)
+{
+
+} /* test__ezq_push__capacity_full__failure */
+
+static void
+test__ezq_push__no_alloc_fn__failure(void)
+{
+
+} /* test__ezq_push__no_alloc_fn__failure */
+
+static void
+test__ezq_push__alloc_fail__failure(void)
+{
+
+} /* test__ezq_push__alloc_fail__failure */
+
+static void
+test__ezq_pop__standard__success(void)
+{
+
+} /* test__ezq_pop__standard__success */
+
+static void
+test__ezq_pop__null_queue__failure(void)
+{
+
+} /* test__ezq_pop__null_queue__failure */
+
+static void
+test__ezq_pop__null_out__failure(void)
+{
+
+} /* test__ezq_pop__null_out__failure */
+
+static void
+test__ezq_pop__empty__failure(void)
+{
+
+} /* test__ezq_pop__empty__failure */
+
+static void
+test__ezq_pop__no_free_fn__failure(void)
+{
+
+} /* test__ezq_pop__no_free_fn__failure */
+
+static void
+test__ezq_count__zero_count__success(void)
+{
+
+} /* test__ezq_count__zero_count__success */
+
+static void
+test__ezq_count__non_zero_count__success(void)
+{
+
+} /* test__ezq_count__non_zero_count__success */
+
+static void
+test__ezq_count__null_queue__failure(void)
+{
+
+} /* test__ezq_count__null_queue__failure */
+
+static void
+test__ezq_destroy__empty_queue__success(void)
+{
+
+} /* test__ezq_destroy__empty_queue__success */
+
+static void
+test__ezq_destroy__non_null_cleanup_fn__success(void)
+{
+
+} /* test__ezq_destroy__non_null_cleanup_fn__success */
+
+static void
+test__ezq_destroy__null_cleanup_fn__success(void)
+{
+
+} /* test__ezq_destroy__null_cleanup_fn__success */
+
+static void
+test__ezq_destroy__null_queue__failure(void)
+{
+
+} /* test__ezq_destroy__null_queue__failure */
+
 int main(int argc, char **argv) {
     UNITY_BEGIN();
 
     RUN_TEST(test__ezq_init__standard__success);
     RUN_TEST(test__ezq_init__null_queue__failure);
+
+    RUN_TEST(test__ezq_push__standard__success);
+    RUN_TEST(test__ezq_push__null_queue__failure);
+    RUN_TEST(test__ezq_push__null_item__failure);
+    RUN_TEST(test__ezq_push__capacity_full__failure);
+    RUN_TEST(test__ezq_push__no_alloc_fn__failure);
+    RUN_TEST(test__ezq_push__alloc_fail__failure);
+
+    RUN_TEST(test__ezq_pop__standard__success);
+    RUN_TEST(test__ezq_pop__null_queue__failure);
+    RUN_TEST(test__ezq_pop__null_out__failure);
+    RUN_TEST(test__ezq_pop__empty__failure);
+    RUN_TEST(test__ezq_pop__no_free_fn__failure);
+
+    RUN_TEST(test__ezq_count__zero_count__success);
+    RUN_TEST(test__ezq_count__non_zero_count__success);
+    RUN_TEST(test__ezq_count__null_queue__failure);
+
+    RUN_TEST(test__ezq_destroy__empty_queue__success);
+    RUN_TEST(test__ezq_destroy__null_cleanup_fn__success);
+    RUN_TEST(test__ezq_destroy__non_null_cleanup_fn__success);
+    RUN_TEST(test__ezq_destroy__null_queue__failure);
 
     return UNITY_END();
 } /* main */

--- a/src/easyqueue.tests.c
+++ b/src/easyqueue.tests.c
@@ -523,22 +523,62 @@ test__ezq_pop__no_free_fn__failure(void)
     TEST_ASSERT_EQUAL_PTR(0xFF, p_item);
 } /* test__ezq_pop__no_free_fn__failure */
 
+/*!
+ * @brief Tests that \c ezq_count succeeds properly when the queue contains
+ * no items.
+ */
 static void
 test__ezq_count__zero_count__success(void)
 {
+    ezq_queue queue = { 0 };
+    ezq_status estat = EZQ_STATUS_UNKNOWN;
+    unsigned int count = 0;
 
+    /* Set any initial state. */
+    queue.fixed.count = 0;
+    queue.dynamic.count = 0;
+
+    /* Invoke the function being tested and verify the expected outcome. */
+    count = ezq_count(&queue, &estat);
+    TEST_ASSERT_EQUAL_UINT(0, count);
+    TEST_ASSERT_EQUAL(EZQ_STATUS_SUCCESS, estat);
 } /* test__ezq_count__zero_count__success */
 
+/*!
+ * @brief Tests that \c ezq_count succeeds properly when the queue contains
+ * any items.
+ */
 static void
 test__ezq_count__non_zero_count__success(void)
 {
+    ezq_queue queue = { 0 };
+    ezq_status estat = EZQ_STATUS_UNKNOWN;
+    unsigned int count = 0;
 
+    /* Set any initial state. */
+    queue.fixed.count = 5;
+    queue.dynamic.count = 3;
+
+    /* Invoke the function being tested and verify the expected outcome. */
+    count = ezq_count(&queue, &estat);
+    TEST_ASSERT_EQUAL_UINT(queue.fixed.count + queue.dynamic.count, count);
+    TEST_ASSERT_EQUAL(EZQ_STATUS_SUCCESS, estat);
 } /* test__ezq_count__non_zero_count__success */
 
+/*!
+ * @brief Test that \c ezq_count fails when passed an \c ezq_queue pointer
+ * that is \c NULL .
+ */
 static void
 test__ezq_count__null_queue__failure(void)
 {
+    ezq_status estat = EZQ_STATUS_UNKNOWN;
+    unsigned int count = 0;
 
+    /* Invoke the function being tested and verify the expected outcome. */
+    count = ezq_count(NULL, &estat);
+    TEST_ASSERT_EQUAL_UINT(0, count);
+    TEST_ASSERT_EQUAL(EZQ_STATUS_NULL_QUEUE, estat);
 } /* test__ezq_count__null_queue__failure */
 
 static void

--- a/src/easyqueue.tests.c
+++ b/src/easyqueue.tests.c
@@ -40,7 +40,7 @@ void tearDown(void) { } /* UNUSED; required definition for Unity tests */
  * no return values have been set on the stack, \c NULL is returned.
  */
 static void *
-alloc_fn_custom(const size_t size)
+custom_alloc_fn(const size_t size)
 {
     void *p_addr = NULL;
 
@@ -59,7 +59,7 @@ alloc_fn_custom(const size_t size)
 done:
     (void)size;
     return p_addr;
-} /* alloc_fn_custom */
+} /* custom_alloc_fn */
 
 /*!
  * @brief Pushes \c ptr to the top of the global dummy allocation stack
@@ -68,14 +68,14 @@ done:
  * @param[in] ptr The address to push onto the stack.
  */
 static void
-alloc_fn_push(void * const ptr)
+custom_alloc_fn_push(void * const ptr)
 {
     if (g_alloc_stack.top_index + 1 < CUSTOM_ALLOC_STACK_SIZE)
     {
         ++g_alloc_stack.top_index;
     }
     g_alloc_stack.return_stack[g_alloc_stack.top_index] = ptr;
-} /* alloc_fn_push */
+} /* custom_alloc_fn_push */
 
 /*!
  * @brief Does nothing.
@@ -86,10 +86,10 @@ alloc_fn_push(void * const ptr)
  * @param[in] ptr UNUSED
  */
 static void
-free_fn_custom(void * const ptr)
+custom_free_fn(void * const ptr)
 {
     (void)ptr;
-} /* free_fn_custom */
+} /* custom_free_fn */
 
 /*!
  * @brief Test that \c ezq_init succeeds when provided standard valid
@@ -108,7 +108,7 @@ test__ezq_init__standard__success(void)
         ((unsigned char *)&queue)[i] = 0xFF;
     }
 
-    estat = ezq_init(&queue, TEST_CAPACITY, alloc_fn_custom, free_fn_custom);
+    estat = ezq_init(&queue, TEST_CAPACITY, custom_alloc_fn, custom_free_fn);
     TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_SUCCESS, estat);
     for (i = 0; i < EZQ_FIXED_BUFFER_CAPACITY; ++i)
     {
@@ -122,8 +122,8 @@ test__ezq_init__standard__success(void)
     TEST_ASSERT_EQUAL(0, queue.dynamic.count);
 
     TEST_ASSERT_EQUAL(TEST_CAPACITY, queue.capacity);
-    TEST_ASSERT_EQUAL_PTR(queue.alloc_fn, alloc_fn_custom);
-    TEST_ASSERT_EQUAL_PTR(queue.free_fn, free_fn_custom);
+    TEST_ASSERT_EQUAL_PTR(queue.alloc_fn, custom_alloc_fn);
+    TEST_ASSERT_EQUAL_PTR(queue.free_fn, custom_free_fn);
 } /* test__ezq_init__standard__success */
 
 /*!
@@ -136,7 +136,7 @@ test__ezq_init__null_queue__failure(void)
     const unsigned int TEST_CAPACITY = 100;
     ezq_status estat = EZQ_STATUS_UNKNOWN;
 
-    estat = ezq_init(NULL, TEST_CAPACITY, alloc_fn_custom, free_fn_custom);
+    estat = ezq_init(NULL, TEST_CAPACITY, custom_alloc_fn, custom_free_fn);
     TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_NULL_QUEUE, estat);
 } /* test__ezq_init__null_queue__failure */
 
@@ -185,8 +185,8 @@ test__ezq_push__list__success(void)
     struct ezq_linkedlist_node node = { NULL, NULL };
 
     /* Set any initial state. */
-    alloc_fn_push(&node);
-    queue.alloc_fn = alloc_fn_custom;
+    custom_alloc_fn_push(&node);
+    queue.alloc_fn = custom_alloc_fn;
     queue.fixed.count = EZQ_FIXED_BUFFER_CAPACITY;
 
     /* Invoke the function being tested and verify the expected outcome. */
@@ -342,7 +342,7 @@ test__ezq_push__alloc_fail__failure(void)
     int *p_item = (int *)0xFF;
 
     /* Set any initial state. */
-    queue.alloc_fn = alloc_fn_custom;
+    queue.alloc_fn = custom_alloc_fn;
     queue.fixed.count = EZQ_FIXED_BUFFER_CAPACITY;
     queue.dynamic.p_head = NULL;
     queue.dynamic.p_tail = NULL;

--- a/src/easyqueue.tests.c
+++ b/src/easyqueue.tests.c
@@ -1,0 +1,102 @@
+#include <stdio.h>
+#include <unity/unity.h>
+#include "easyqueue.h"
+
+void setUp(void) { } /* UNUSED; required definition for Unity tests */
+void tearDown(void) { } /* UNUSED; required definition for Unity tests */
+
+/*!
+ * @brief Dummy function that returns a pointer value that is not \c NULL .
+ *
+ * @param[in] size UNUSED
+ * @return In all cases, a pointer value that is not \c NULL .
+ */
+static void *
+alloc_fn_success(const size_t size)
+{
+    (void)size;
+    return (void *)(-1);
+} /* alloc_fn_success */
+
+/*!
+ * @brief Dummy function that returns a \c NULL pointer value.
+ *
+ * @param[in] size UNUSED
+ * @return In all cases, \c NULL .
+ */
+static void *
+alloc_fn_failure(const size_t size)
+{
+    (void)size;
+    return NULL;
+} /* alloc_fn_failure */
+
+/*!
+ * @brief Dummy function that matches the signature of \c free() , but
+ * does not actually perform any operations.
+ *
+ * @param[in] ptr UNUSED
+ */
+static void
+free_fn_no_op(void * const ptr)
+{
+    (void)ptr;
+} /* free_fn_no_op */
+
+/*!
+ * @brief Test that \c ezq_init succeeds when provided standard valid
+ * arguments.
+ */
+static void
+test__ezq_init__standard__success(void)
+{
+    const unsigned int TEST_CAPACITY = 100;
+    ezq_status estat = EZQ_STATUS_UNKNOWN;
+    ezq_queue queue = { 0 };
+    int i = 0;
+
+    for (i = 0; i < sizeof(queue); ++i)
+    {
+        ((unsigned char *)&queue)[i] = 0xFF;
+    }
+
+    estat = ezq_init(&queue, TEST_CAPACITY, alloc_fn_success, free_fn_no_op);
+    TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_SUCCESS, estat);
+    for (i = 0; i < EZQ_FIXED_BUFFER_CAPACITY; ++i)
+    {
+        TEST_ASSERT_NULL(queue.fixed.p_items[i]);
+    }
+    TEST_ASSERT_EQUAL_UINT32(0, queue.fixed.front_index);
+    TEST_ASSERT_EQUAL_UINT32(0, queue.fixed.count);
+
+    TEST_ASSERT_NULL(queue.dynamic.p_head);
+    TEST_ASSERT_NULL(queue.dynamic.p_tail);
+    TEST_ASSERT_EQUAL(0, queue.dynamic.count);
+
+    TEST_ASSERT_EQUAL(TEST_CAPACITY, queue.capacity);
+    TEST_ASSERT_EQUAL_PTR(queue.alloc_fn, alloc_fn_success);
+    TEST_ASSERT_EQUAL_PTR(queue.free_fn, free_fn_no_op);
+} /* test__ezq_init__standard__success */
+
+/*!
+ * @brief Test that \c ezq_init properly fails when passed a \c NULL
+ * \c ezq_queue* .
+ */
+static void
+test__ezq_init__null_queue__failure(void)
+{
+    const unsigned int TEST_CAPACITY = 100;
+    ezq_status estat = EZQ_STATUS_UNKNOWN;
+
+    estat = ezq_init(NULL, TEST_CAPACITY, alloc_fn_success, free_fn_no_op);
+    TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_NULL_QUEUE, estat);
+} /* test__ezq_init__null_queue__failure */
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test__ezq_init__standard__success);
+    RUN_TEST(test__ezq_init__null_queue__failure);
+
+    return UNITY_END();
+} /* main */

--- a/src/easyqueue.tests.c
+++ b/src/easyqueue.tests.c
@@ -1,47 +1,95 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <unity/unity.h>
 #include "easyqueue.h"
 
-void setUp(void) { } /* UNUSED; required definition for Unity tests */
+#define CUSTOM_ALLOC_STACK_SIZE (16)
+
+struct alloc_stack
+{
+    void *return_stack[CUSTOM_ALLOC_STACK_SIZE];
+    int top_index;
+} g_alloc_stack;
+
+/*!
+ * @brief Sets the global dummy allocation stack to default values.
+ *
+ * @note This function's implementation (regardless of what it actually does)
+ * is required by the Unity test framework.
+ */
+void setUp(void)
+{
+    unsigned int i = 0;
+
+    for (i = 0; i < CUSTOM_ALLOC_STACK_SIZE; ++i)
+    {
+        g_alloc_stack.return_stack[i] = NULL;
+    }
+    g_alloc_stack.top_index = -1;
+}
+
 void tearDown(void) { } /* UNUSED; required definition for Unity tests */
 
 /*!
- * @brief Dummy function that returns a pointer value that is not \c NULL .
+ * @brief Pops the address at the top of global dummy allocation stack and
+ * returns it.
  *
  * @param[in] size UNUSED
- * @return In all cases, a pointer value that is not \c NULL .
- */
-static void *
-alloc_fn_success(const size_t size)
-{
-    (void)size;
-    return (void *)(-1);
-} /* alloc_fn_success */
-
-/*!
- * @brief Dummy function that returns a \c NULL pointer value.
  *
- * @param[in] size UNUSED
- * @return In all cases, \c NULL .
+ * @return The address at the top of the global dummy allocation stack. If
+ * no return values have been set on the stack, \c NULL is returned.
  */
 static void *
-alloc_fn_failure(const size_t size)
+alloc_fn_custom(const size_t size)
 {
+    void *p_addr = NULL;
+
+    if (g_alloc_stack.top_index < 0)
+    {
+        goto done;
+    }
+
+    p_addr = g_alloc_stack.return_stack[g_alloc_stack.top_index];
+    g_alloc_stack.return_stack[g_alloc_stack.top_index] = NULL;
+    if (g_alloc_stack.top_index > 0)
+    {
+        --g_alloc_stack.top_index;
+    }
+
+done:
     (void)size;
-    return NULL;
-} /* alloc_fn_failure */
+    return p_addr;
+} /* alloc_fn_custom */
 
 /*!
- * @brief Dummy function that matches the signature of \c free() , but
- * does not actually perform any operations.
+ * @brief Pushes \c ptr to the top of the global dummy allocation stack
+ * such that it will be returned by the next call to \c alloc_fn_custom() .
+ *
+ * @param[in] ptr The address to push onto the stack.
+ */
+static void
+alloc_fn_push(void * const ptr)
+{
+    if (g_alloc_stack.top_index + 1 < CUSTOM_ALLOC_STACK_SIZE)
+    {
+        ++g_alloc_stack.top_index;
+    }
+    g_alloc_stack.return_stack[g_alloc_stack.top_index] = ptr;
+} /* alloc_fn_push */
+
+/*!
+ * @brief Does nothing.
+ *
+ * @note This function mirrors the signature of the standard library's
+ * \c free() function.
  *
  * @param[in] ptr UNUSED
  */
 static void
-free_fn_no_op(void * const ptr)
+free_fn_custom(void * const ptr)
 {
     (void)ptr;
-} /* free_fn_no_op */
+} /* free_fn_custom */
 
 /*!
  * @brief Test that \c ezq_init succeeds when provided standard valid
@@ -60,7 +108,7 @@ test__ezq_init__standard__success(void)
         ((unsigned char *)&queue)[i] = 0xFF;
     }
 
-    estat = ezq_init(&queue, TEST_CAPACITY, alloc_fn_success, free_fn_no_op);
+    estat = ezq_init(&queue, TEST_CAPACITY, alloc_fn_custom, free_fn_custom);
     TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_SUCCESS, estat);
     for (i = 0; i < EZQ_FIXED_BUFFER_CAPACITY; ++i)
     {
@@ -74,8 +122,8 @@ test__ezq_init__standard__success(void)
     TEST_ASSERT_EQUAL(0, queue.dynamic.count);
 
     TEST_ASSERT_EQUAL(TEST_CAPACITY, queue.capacity);
-    TEST_ASSERT_EQUAL_PTR(queue.alloc_fn, alloc_fn_success);
-    TEST_ASSERT_EQUAL_PTR(queue.free_fn, free_fn_no_op);
+    TEST_ASSERT_EQUAL_PTR(queue.alloc_fn, alloc_fn_custom);
+    TEST_ASSERT_EQUAL_PTR(queue.free_fn, free_fn_custom);
 } /* test__ezq_init__standard__success */
 
 /*!
@@ -88,51 +136,145 @@ test__ezq_init__null_queue__failure(void)
     const unsigned int TEST_CAPACITY = 100;
     ezq_status estat = EZQ_STATUS_UNKNOWN;
 
-    estat = ezq_init(NULL, TEST_CAPACITY, alloc_fn_success, free_fn_no_op);
+    estat = ezq_init(NULL, TEST_CAPACITY, alloc_fn_custom, free_fn_custom);
     TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_NULL_QUEUE, estat);
 } /* test__ezq_init__null_queue__failure */
 
 static void
-test__ezq_push__standard__success(void)
+test__ezq_push__buf__success(void)
 {
+    ezq_queue queue = { 0 };
+    ezq_status estat = EZQ_STATUS_UNKNOWN;
+    int *p_item = (int *)0xFF;
 
-} /* test__ezq_push__standard__success */
+    estat = ezq_push(&queue, p_item);
+    TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_SUCCESS, estat);
+    TEST_ASSERT_EQUAL_PTR(p_item, queue.fixed.p_items[0]);
+    TEST_ASSERT_EQUAL_UINT32(1, queue.fixed.count);
+    TEST_ASSERT_EQUAL_UINT32(0, queue.fixed.front_index);
+} /* test__ezq_push__buf__success */
+
+static void
+test__ezq_push__list__success(void)
+{
+    ezq_queue queue = { 0 };
+    ezq_status estat = EZQ_STATUS_UNKNOWN;
+    int *p_item = (int *)0xFF;
+    struct ezq_linkedlist_node node = { NULL, NULL };
+
+    alloc_fn_push(&node);
+    queue.alloc_fn = alloc_fn_custom;
+    queue.fixed.count = EZQ_FIXED_BUFFER_CAPACITY;
+
+    estat = ezq_push(&queue, p_item);
+    TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_SUCCESS, estat);
+    TEST_ASSERT_EQUAL_PTR(&node, queue.dynamic.p_head);
+    TEST_ASSERT_EQUAL_PTR(&node, queue.dynamic.p_tail);
+    TEST_ASSERT_EQUAL_PTR(p_item, node.p_item);
+    TEST_ASSERT_NULL(node.p_next);
+} /* test__ezq_push__list__success */
 
 static void
 test__ezq_push__null_queue__failure(void)
 {
+    ezq_status estat = EZQ_STATUS_UNKNOWN;
+    int *p_item = (int *)0xFF;
 
+    estat = ezq_push(NULL, p_item);
+    TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_NULL_QUEUE, estat);
 } /* test__ezq_push__null_queue__failure */
 
 static void
 test__ezq_push__null_item__failure(void)
 {
+    ezq_queue queue = { 0 };
+    ezq_status estat = EZQ_STATUS_UNKNOWN;
 
+    queue.fixed.count = 0;
+    queue.fixed.p_items[0] = NULL;
+    queue.dynamic.count = 0;
+    queue.dynamic.p_head = NULL;
+    queue.dynamic.p_tail = NULL;
+
+    estat = ezq_push(&queue, NULL);
+    TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_NULL_ITEM, estat);
+    TEST_ASSERT_EQUAL_UINT32(0, queue.fixed.count);
+    TEST_ASSERT_EQUAL_UINT32(0, queue.dynamic.count);
+    TEST_ASSERT_NULL(queue.fixed.p_items[0]);
+    TEST_ASSERT_NULL(queue.dynamic.p_head);
+    TEST_ASSERT_NULL(queue.dynamic.p_tail);
 } /* test__ezq_push__null_item__failure */
 
 static void
 test__ezq_push__capacity_full__failure(void)
 {
+    ezq_queue queue = { 0 };
+    ezq_status estat = EZQ_STATUS_UNKNOWN;
+    int *p_item = (int *)0xFF;
 
+    queue.capacity = 1;
+    queue.fixed.count = 1;
+    queue.dynamic.count = 0;
+
+    estat = ezq_push(&queue, p_item);
+    TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_FULL, estat);
+    TEST_ASSERT_EQUAL_UINT32(1, queue.fixed.count);
+    TEST_ASSERT_EQUAL_UINT32(0, queue.dynamic.count);
 } /* test__ezq_push__capacity_full__failure */
 
 static void
 test__ezq_push__no_alloc_fn__failure(void)
 {
+    ezq_queue queue = { 0 };
+    ezq_status estat = EZQ_STATUS_UNKNOWN;
+    int *p_item = (int *)0xFF;
 
+    queue.alloc_fn = NULL;
+    queue.fixed.count = EZQ_FIXED_BUFFER_CAPACITY;
+    queue.dynamic.p_head = NULL;
+    queue.dynamic.p_tail = NULL;
+    queue.dynamic.count = 0;
+
+    estat = ezq_push(&queue, p_item);
+    TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_NO_ALLOC_FN, estat);
+    TEST_ASSERT_EQUAL_UINT32(EZQ_FIXED_BUFFER_CAPACITY, queue.fixed.count);
+    TEST_ASSERT_EQUAL_UINT32(0, queue.dynamic.count);
+    TEST_ASSERT_NULL(queue.dynamic.p_head);
+    TEST_ASSERT_NULL(queue.dynamic.p_tail);
 } /* test__ezq_push__no_alloc_fn__failure */
 
 static void
 test__ezq_push__alloc_fail__failure(void)
 {
+    ezq_queue queue = { 0 };
+    ezq_status estat = EZQ_STATUS_UNKNOWN;
+    int *p_item = (int *)0xFF;
 
+    queue.alloc_fn = alloc_fn_custom;
+    queue.fixed.count = EZQ_FIXED_BUFFER_CAPACITY;
+    queue.dynamic.p_head = NULL;
+    queue.dynamic.p_tail = NULL;
+    queue.dynamic.count = 0;
+
+    estat = ezq_push(&queue, p_item);
+    TEST_ASSERT_EQUAL_UINT8(EZQ_STATUS_ALLOC_FAILURE, estat);
+    TEST_ASSERT_EQUAL_UINT32(EZQ_FIXED_BUFFER_CAPACITY, queue.fixed.count);
+    TEST_ASSERT_EQUAL_UINT32(0, queue.dynamic.count);
+    TEST_ASSERT_NULL(queue.dynamic.p_head);
+    TEST_ASSERT_NULL(queue.dynamic.p_tail);
 } /* test__ezq_push__alloc_fail__failure */
 
 static void
-test__ezq_pop__standard__success(void)
+test__ezq_pop__empty_list__success(void)
 {
 
-} /* test__ezq_pop__standard__success */
+} /* test__ezq_pop__empty_list__success */
+
+static void
+test__ezq_pop__non_empty_list__success(void)
+{
+
+} /* test__ezq_pop__non_empty_list__success */
 
 static void
 test__ezq_pop__null_queue__failure(void)
@@ -206,14 +348,16 @@ int main(int argc, char **argv) {
     RUN_TEST(test__ezq_init__standard__success);
     RUN_TEST(test__ezq_init__null_queue__failure);
 
-    RUN_TEST(test__ezq_push__standard__success);
+    RUN_TEST(test__ezq_push__buf__success);
+    RUN_TEST(test__ezq_push__list__success);
     RUN_TEST(test__ezq_push__null_queue__failure);
     RUN_TEST(test__ezq_push__null_item__failure);
     RUN_TEST(test__ezq_push__capacity_full__failure);
     RUN_TEST(test__ezq_push__no_alloc_fn__failure);
     RUN_TEST(test__ezq_push__alloc_fail__failure);
 
-    RUN_TEST(test__ezq_pop__standard__success);
+    RUN_TEST(test__ezq_pop__empty_list__success);
+    RUN_TEST(test__ezq_pop__non_empty_list__success);
     RUN_TEST(test__ezq_pop__null_queue__failure);
     RUN_TEST(test__ezq_pop__null_out__failure);
     RUN_TEST(test__ezq_pop__empty__failure);


### PR DESCRIPTION
The following changes have been made:

1. Units tests were added for the following functions:
   - `ezq_init`
   - `ezq_count`
   - `ezq_push`
   - `ezq_pop`
   - `ezq_destroy`
2. The following changes were made to existing functions:
   - `ezq_pop`
     - Now sets the tail of the underlying linked list to `NULL` if the last item in the list is popped
   - `ezq_destroy`
     - Now returns `EZQ_STATUS_NO_FREE_FN` if the the passed `ezq_queue` to has a `NULL` `free_fn` but the underlying linked list contains items
       - The members of the passed `ezq_queue` are not modified in this case
     - Now sets the `alloc_fn` and `free_fn` fields to `NULL` on success
     - Now sets the `capacity` field to `0` on success